### PR TITLE
Azure deployment template to setup Azure Key Vault as EKM provider on a SQL Server on Azure VM

### DIFF
--- a/100-sqlvm-setupkeyvault/README.md
+++ b/100-sqlvm-setupkeyvault/README.md
@@ -1,0 +1,11 @@
+# This template setup Azure Key Vault on any existing Azure Virtual machine with SQL Server Standard or Enterprise edition.
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F100-sqlvm-setupkeyvaulty%2Fazuredeploy.json" target="_blank">
+  <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F100-sqlvm-setupkeyvaulty%2Fazuredeploy.json" target="_blank">
+  <img src="http://armviz.io/visualizebutton.png"/>
+</a>
+
+This template setup Azure Key Vault on any existing Azure Virtual machine with SQL Server Standard or Enterprise edition. Azure Key Vault provider is configured on SQL Server as an EKM provider and a new credential is created on the SQL Server that with its keys secured in Azure Key Vault provided in the parameters. User can also create credentials on the server using the same provider and store.
+

--- a/100-sqlvm-setupkeyvault/azuredeploy.json
+++ b/100-sqlvm-setupkeyvault/azuredeploy.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "virtualMachineName": {
+            "type": "string",
+             "metadata": {
+                "description": "SQL Server virtual machine"
+             }
+        },
+        "location": {
+            "type": "string",
+            "metadata": {
+                "description": "SQL Server virtual machine location"
+            }
+        },
+        "sqlCredentialName": { 
+            "type": "string",
+            "metadata": {
+                "description": "SQL credential name to create on the SQL Server virtual machine"
+            }
+        },
+        "vaultUrl": {
+            "type": "string",
+            "metadata": {
+                "description": "Azure Key Vault URL"
+            }
+        },
+        "servicePrincipalName": {
+            "type": "string",
+            "metadata": {
+                "description": "Azure Key Vault principal name or id"
+            }
+        },
+        "servicePrincipalSecret": {
+            "type": "securestring",
+            "metadata": {
+                "description": "Azure Key Vault principal secret"
+            }
+        }
+    },
+    "resources": [
+        {
+            "apiVersion": "2015-06-15",
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(parameters('virtualMachineName'), '/SqlIaasExtension')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "type": "SqlIaaSAgent",
+                "publisher": "Microsoft.SqlServer.Management",
+                "typeHandlerVersion": "1.2",
+                "autoUpgradeMinorVersion": "true",
+                "settings": {
+                    "KeyVaultCredentialSettings": {
+                        "Enable": true,
+                        "CredentialName": "[parameters('sqlCredentialName')]"
+                    }
+                },
+                "protectedSettings": {
+                    "PrivateKeyVaultCredentialSettings": {
+                        "AzureKeyVaultUrl": "[parameters('vaultUrl')]",
+                        "ServicePrincipalName": "[parameters('servicePrincipalName')]",
+                        "ServicePrincipalSecret": "[parameters('servicePrincipalSecret')]"
+                    }
+                }
+            }
+          }
+    ],
+    "outputs": 
+    {
+    }
+}

--- a/100-sqlvm-setupkeyvault/azuredeploy.parameters.json
+++ b/100-sqlvm-setupkeyvault/azuredeploy.parameters.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+        "virtualMachineName": {
+            "value": "changeme"
+        },
+        "location": {
+            "value": "changeme"
+        },
+        "sqlCredentialName": { 
+            "value": "changeme"
+        },
+        "vaultUrl": {
+            "value": "url"
+        },
+        "servicePrincipalName": {
+            "value": "changeme"
+        },
+        "servicePrincipalSecret": {
+            "value": "changeme"
+        }
+    }
+}

--- a/100-sqlvm-setupkeyvault/metadata.json
+++ b/100-sqlvm-setupkeyvault/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Setup SQL Server credentials using Azure Key Vault",
+  "description": "This template setup or update an existing SQL Server on Azure VM credentials secured by Azure Key Vault",
+  "summary": "Setup SQL Server credentials using Azure Key Vault",
+  "githubUsername": "OJDUDE",
+  "dateUpdated": "2016-2-12"
+}


### PR DESCRIPTION
This template setup Azure Key Vault on any existing Azure Virtual machine with SQL Server Standard or Enterprise edition. Azure Key Vault provider is configured on SQL Server as an EKM provider and a new credential is created on the SQL Server that with its keys secured in Azure Key Vault provided in the parameters. User can also create credentials on the server using the same provider and store.
